### PR TITLE
Add toolbar compact mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,18 @@
+# Linux FM
+.hidden
+.directory
+# Byte-compiled / optimized / DLL files
+*.pyo
+*.pyc
+__pycache__/
+# Python
+.python-version
+.mypy_cache/
+.ropeproject
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/

--- a/config.json
+++ b/config.json
@@ -1,3 +1,4 @@
 {
-    "switch to dark theme when add-on night mode is enabled": true
+    "switch to dark theme when add-on night mode is enabled": true,
+    "enable compact mode": false
   }

--- a/fastbar.py
+++ b/fastbar.py
@@ -110,6 +110,29 @@ class Fastbar:
             icon_delete = qta.icon('fa.trash-o')
             icon_resched = qta.icon('fa.sign-in')
             icon_repos = qta.icon('fa.history')
+        
+        if gc("enable compact mode"):
+            # TODO: Create custom QToolBar widget to handle word-wrapping
+            # properly
+            for action_name in (
+                "actionToggle_Fastbar", "actionToggle_Sidebar", "actionAdd",
+                "action_Info", "actionToggle_Mark", "actionToggle_Suspend",
+                "actionToggle_Bury", "actionChange_Deck", "actionChangeModel",
+                "actionAdd_Tags", "actionRemove_Tags", "actionClear_Unused_Tags",
+                "actionDelete", "actionReschedule", "actionReposition"
+            ):
+                action = getattr(self.form, action_name, None)
+                if action is None:
+                    continue
+                action_text = action.text()
+                if " " in action_text:
+                    word_wrapped_text = action_text.replace(" ", "\n", 1)
+                else:
+                    # hacky way to align single-line labels
+                    # "\n" contains an invisible space, since qt strips tailing whitespace
+                    word_wrapped_text = action_text + "\n‎"
+                action.setText(word_wrapped_text)
+
         self.form.actionToggle_Fastbar.setIcon(icon_fastbar)
         self.form.actionToggle_Sidebar.setIcon(icon_sidebar)
         self.form.actionAdd.setIcon(icon_add)

--- a/meta.json
+++ b/meta.json
@@ -1,1 +1,0 @@
-{"name": "Fastbar- with nightmode support"}


### PR DESCRIPTION
Adds a new option, `enable compact mode`, that introduces word wrapping to the toolbar labels, making for a more compact look.

The way word-wrapping is implemented at the moment is very hacky. This is because QActions do not natively support word-wrapping. A proper solution would involve writing a custom QToolbar or QAction class, but for the time being this hack seems to do a fairly good job.

This PR also adds a basic .gitignore file in order to exclude some cache files and local configuration from version tracking.