### PR TITLE
fix Bettersearch/extended tag button

### DIFF
--- a/fastbar.py
+++ b/fastbar.py
@@ -239,7 +239,7 @@ def make_and_add_toolbar(self):  # self is browser
     else:
         tb.setStyleSheet("QToolBar{spacing:0px;}")
     self.addToolBar(tb)  # addToolBar is a method of QMainWindow (that the Browser inherits from)
-gui_hooks.browser_menus_did_init.append(make_and_add_toolbar)
+gui_hooks.browser_will_show.append(make_and_add_toolbar)
 
 
 def setupUi(Ui_Dialog_instance, Dialog):


### PR DESCRIPTION
when adding the toolbar this add-on checks if extended tag dialog has added an
entry to the browser menu. So the function make_and_add_toolbar from this
add-on must run after the hooked functions from the other add-ons have run.
So I may not use a gui_hook that runs early during the browser setup but
instead I must one that is run at the end of the initialization.


If I had tested properly I would have found out. You should test all buttons of the latest version but it should work.

Two problems remain:

- the warning "requireReset() is obsolete; please use CollectionOp()" needs to be adressed
- I really don't like the custom function unburied cards that directly manipulates the database. 