### PR TITLE
Unbury 

### DIFF
--- a/fastbar.py
+++ b/fastbar.py
@@ -239,7 +239,7 @@ def make_and_add_toolbar(self):  # self is browser
     else:
         tb.setStyleSheet("QToolBar{spacing:0px;}")
     self.addToolBar(tb)  # addToolBar is a method of QMainWindow (that the Browser inherits from)
-gui_hooks.browser_menus_did_init.append(make_and_add_toolbar)
+gui_hooks.browser_will_show.append(make_and_add_toolbar)
 
 
 def setupUi(Ui_Dialog_instance, Dialog):

--- a/fastbar.py
+++ b/fastbar.py
@@ -138,30 +138,11 @@ def _onBury(self):  # self is browser
     bur = not isBuried(self)
     c = self.selectedCards()
     if bur:
-        mw.col.sched.buryCards(c)
+        self.col.sched.buryCards(c)
     else:
-        unburiedCards(self, c)
+        self.col.sched.unbury_cards(c)
     self.model.reset()
     self.mw.requireReset()
-
-
-def unburiedCards(self, ids):  # self is browser
-    "Unburied cards."
-    self.col.log(ids)
-    if self.col.schedVer() == 1:
-        self.col.db.execute(
-            "update cards set queue=type,mod=?,usn=? "
-            "where queue = -2 and id in " + ids2str(ids),
-            intTime(),
-            self.col.usn(),
-        )
-    elif self.col.schedVer() in [2, 3]:
-        self.col.db.execute(
-            "update cards set queue=type,mod=?,usn=? "
-            "where queue in (-2,-3) and id in " + ids2str(ids),
-            intTime(),
-            self.col.usn(),
-        )
 
 
 def make_and_add_toolbar(self):  # self is browser


### PR DESCRIPTION
If I remember correctly anki used to have only a function to unbury all cards
and to unbury all cards in a deck but not to unbury a list of card ids.
That's why a custom function made sense.
But as far as I see about a year ago a method to unbury a list of card ids
was introduced with:
https://github.com/ankitects/anki//commit/ccfa989c62d2477926a88b3d140527161ca5b74b
So we should use the new sched.unbury_cards


Just to be sure: Test this, e.g. with cards in different decks etc. My problem 
here is that the new scheduler code is in rust ...



This pull request seems to also contain the commit from my first pull request. So I'm closing the old one again.